### PR TITLE
Create base builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.nirmata.workflow</groupId>
     <artifactId>nirmata-workflow</artifactId>
-    <version>0.10.8-SNAPSHOT</version>
+    <version>0.10.9-SNAPSHOT</version>
 
     <properties>
         <jdk-version>1.8</jdk-version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.nirmata.workflow</groupId>
     <artifactId>nirmata-workflow</artifactId>
-    <version>0.10.5-SNAPSHOT</version>
+    <version>0.10.8-SNAPSHOT</version>
 
     <properties>
         <jdk-version>1.8</jdk-version>

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerBaseBuilder.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerBaseBuilder.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 Nirmata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nirmata.workflow;
 
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerBaseBuilder.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerBaseBuilder.java
@@ -1,0 +1,143 @@
+package com.nirmata.workflow;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.nirmata.workflow.admin.AutoCleaner;
+import com.nirmata.workflow.details.AutoCleanerHolder;
+import com.nirmata.workflow.details.TaskExecutorSpec;
+import com.nirmata.workflow.executor.TaskExecutor;
+import com.nirmata.workflow.models.TaskType;
+import com.nirmata.workflow.queue.QueueFactory;
+import com.nirmata.workflow.queue.zookeeper.ZooKeeperSimpleQueueFactory;
+import com.nirmata.workflow.serialization.Serializer;
+import com.nirmata.workflow.serialization.StandardSerializer;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+public abstract class WorkflowManagerBaseBuilder {
+
+    protected final List<TaskExecutorSpec> specs = Lists.newArrayList();
+    protected QueueFactory queueFactory = new ZooKeeperSimpleQueueFactory();
+    protected String instanceName;
+    protected AutoCleanerHolder autoCleanerHolder = newNullHolder();
+    protected Serializer serializer = new StandardSerializer();
+    protected Executor taskRunnerService = MoreExecutors.newDirectExecutorService();
+
+    /**
+     * <p>
+     * Adds a pool of task executors for a given task type to this instance of
+     * the workflow. The specified number of executors are allocated. Call this
+     * method multiple times to allocate executors for the various types of tasks
+     * that will be used in this workflow. You can choose to have all workflow
+     * instances execute all task types or target certain task types to certain instances.
+     * </p>
+     *
+     * <p>
+     * <code>qty</code> is the maximum concurrency for the given type of task for this instance.
+     * The logical concurrency for a given task type is the total qty of all instances in the
+     * workflow. e.g. if there are 3 instances in the workflow and instance A has 2 executors
+     * for task type "a", instance B has 3 executors for task type "a" and instance C has no
+     * executors for task type "a", the maximum concurrency for task type "a" is 5.
+     * </p>
+     *
+     * <p>
+     * IMPORTANT: every workflow cluster must have at least one instance that has task executor(s)
+     * for each task type that will be submitted to the workflow. i.e workflows will stall
+     * if there is no executor for a given task type.
+     * </p>
+     *
+     * @param taskExecutor the executor
+     * @param qty          the number of instances for this pool
+     * @param taskType     task type
+     * @return this (for chaining)
+     */
+    public WorkflowManagerBaseBuilder addingTaskExecutor(TaskExecutor taskExecutor, int qty, TaskType taskType) {
+        specs.add(new TaskExecutorSpec(taskExecutor, qty, taskType));
+        return this;
+    }
+
+    /**
+     * <em>optional</em><br>
+     * <p>
+     * Used in reporting. This will be the value recorded as tasks are executed. Via reporting,
+     * you can determine which instance has executed a given task.
+     * </p>
+     *
+     * <p>
+     * Default is: <code>InetAddress.getLocalHost().getHostName()</code>
+     * </p>
+     *
+     * @param instanceName the name of this instance
+     * @return this (for chaining)
+     */
+    public WorkflowManagerBaseBuilder withInstanceName(String instanceName) {
+        this.instanceName = Preconditions.checkNotNull(instanceName, "instanceName cannot be null");
+        return this;
+    }
+
+    /**
+     * Return a new WorkflowManager using the current builder values
+     *
+     * @return new WorkflowManager
+     */
+    public abstract WorkflowManager build();
+
+    /**
+     * <em>optional</em><br>
+     * Pluggable queue factory. Default uses ZooKeeper for queuing.
+     *
+     * @param queueFactory new queue factory
+     * @return this (for chaining)
+     */
+    public WorkflowManagerBaseBuilder withQueueFactory(QueueFactory queueFactory) {
+        this.queueFactory = Preconditions.checkNotNull(queueFactory, "queueFactory cannot be null");
+        return this;
+    }
+
+    /**
+     * <em>optional</em><br>
+     * Sets an auto-cleaner that will run every given period. This is used to clean old runs.
+     * IMPORTANT: the auto cleaner will only run on the instance that is the current scheduler.
+     *
+     * @param autoCleaner the auto cleaner to use
+     * @param runPeriod   how often to run
+     * @return this (for chaining)
+     */
+    public WorkflowManagerBaseBuilder withAutoCleaner(AutoCleaner autoCleaner, Duration runPeriod) {
+        autoCleanerHolder = (autoCleaner == null) ? newNullHolder() : new AutoCleanerHolder(autoCleaner, runPeriod);
+        return this;
+    }
+
+    /**
+     * <em>optional</em><br>
+     * By default, a JSON serializer is used to store data in ZooKeeper. Use this to specify an alternate serializer
+     *
+     * @param serializer serializer to use
+     * @return this (for chaining)
+     */
+    public WorkflowManagerBaseBuilder withSerializer(Serializer serializer) {
+        this.serializer = Preconditions.checkNotNull(serializer, "serializer cannot be null");
+        return this;
+    }
+
+    /**
+     * <em>optional</em><br>
+     * By default, tasks are run in an internal executor service. Use this to specify a custom executor service
+     * for tasks. This executor does not add any async/concurrency benefit. It's purpose is to allow you to control
+     * which thread executes your tasks.
+     *
+     * @param taskRunnerService custom executor service
+     * @return this (for chaining)
+     */
+    public WorkflowManagerBaseBuilder withTaskRunnerService(Executor taskRunnerService) {
+        this.taskRunnerService = Preconditions.checkNotNull(taskRunnerService, "taskRunnerService cannot be null");
+        return this;
+    }
+
+    AutoCleanerHolder newNullHolder() {
+        return new AutoCleanerHolder(null, Duration.ofDays(Integer.MAX_VALUE));
+    }
+}

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerBuilder.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerBuilder.java
@@ -16,39 +16,19 @@
 package com.nirmata.workflow;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.nirmata.workflow.admin.AutoCleaner;
-import com.nirmata.workflow.details.AutoCleanerHolder;
-import com.nirmata.workflow.details.TaskExecutorSpec;
 import com.nirmata.workflow.details.WorkflowManagerImpl;
-import com.nirmata.workflow.executor.TaskExecutor;
-import com.nirmata.workflow.models.TaskType;
-import com.nirmata.workflow.queue.QueueFactory;
 import com.nirmata.workflow.queue.zookeeper.ZooKeeperSimpleQueueFactory;
-import com.nirmata.workflow.serialization.Serializer;
-import com.nirmata.workflow.serialization.StandardSerializer;
 import org.apache.curator.framework.CuratorFramework;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.Executor;
 
 /**
  * Builds {@link WorkflowManager} instances
  */
-public class WorkflowManagerBuilder
-{
-    private QueueFactory queueFactory = new ZooKeeperSimpleQueueFactory();
-    private String instanceName;
+public class WorkflowManagerBuilder extends WorkflowManagerBaseBuilder{
+
     private CuratorFramework curator;
-    private AutoCleanerHolder autoCleanerHolder = newNullHolder();
-    private Serializer serializer = new StandardSerializer();
-    private Executor taskRunnerService = MoreExecutors.newDirectExecutorService();
-
-    private final List<TaskExecutorSpec> specs = Lists.newArrayList();
-
     /**
      * Return a new builder
      *
@@ -81,127 +61,19 @@ public class WorkflowManagerBuilder
     }
 
     /**
-     * <p>
-     *     Adds a pool of task executors for a given task type to this instance of
-     *     the workflow. The specified number of executors are allocated. Call this
-     *     method multiple times to allocate executors for the various types of tasks
-     *     that will be used in this workflow. You can choose to have all workflow
-     *     instances execute all task types or target certain task types to certain instances.
-     * </p>
-     *
-     * <p>
-     *     <code>qty</code> is the maximum concurrency for the given type of task for this instance.
-     *     The logical concurrency for a given task type is the total qty of all instances in the
-     *     workflow. e.g. if there are 3 instances in the workflow and instance A has 2 executors
-     *     for task type "a", instance B has 3 executors for task type "a" and instance C has no
-     *     executors for task type "a", the maximum concurrency for task type "a" is 5.
-     * </p>
-     *
-     * <p>
-     *     IMPORTANT: every workflow cluster must have at least one instance that has task executor(s)
-     *     for each task type that will be submitted to the workflow. i.e workflows will stall
-     *     if there is no executor for a given task type.
-     * </p>
-     *
-     * @param taskExecutor the executor
-     * @param qty the number of instances for this pool
-     * @param taskType task type
-     * @return this (for chaining)
-     */
-    public WorkflowManagerBuilder addingTaskExecutor(TaskExecutor taskExecutor, int qty, TaskType taskType)
-    {
-        specs.add(new TaskExecutorSpec(taskExecutor, qty, taskType));
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * <p>
-     *     Used in reporting. This will be the value recorded as tasks are executed. Via reporting,
-     *     you can determine which instance has executed a given task.
-     * </p>
-     *
-     * <p>
-     *     Default is: <code>InetAddress.getLocalHost().getHostName()</code>
-     * </p>
-     *
-     * @param instanceName the name of this instance
-     * @return this (for chaining)
-     */
-    public WorkflowManagerBuilder withInstanceName(String instanceName)
-    {
-        this.instanceName = Preconditions.checkNotNull(instanceName, "instanceName cannot be null");
-        return this;
-    }
-
-    /**
      * Return a new WorkflowManager using the current builder values
      *
      * @return new WorkflowManager
      */
+    @Override
     public WorkflowManager build()
     {
         return new WorkflowManagerImpl(curator, queueFactory, instanceName, specs, autoCleanerHolder, serializer, taskRunnerService);
     }
-
-    /**
-     * <em>optional</em><br>
-     * Pluggable queue factory. Default uses ZooKeeper for queuing.
-     *
-     * @param queueFactory new queue factory
-     * @return this (for chaining)
-     */
-    public WorkflowManagerBuilder withQueueFactory(QueueFactory queueFactory)
-    {
-        this.queueFactory = Preconditions.checkNotNull(queueFactory, "queueFactory cannot be null");
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * Sets an auto-cleaner that will run every given period. This is used to clean old runs.
-     * IMPORTANT: the auto cleaner will only run on the instance that is the current scheduler.
-     *
-     * @param autoCleaner the auto cleaner to use
-     * @param runPeriod how often to run
-     * @return this (for chaining)
-     */
-    public WorkflowManagerBuilder withAutoCleaner(AutoCleaner autoCleaner, Duration runPeriod)
-    {
-        autoCleanerHolder = (autoCleaner == null) ? newNullHolder() : new AutoCleanerHolder(autoCleaner, runPeriod);
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * By default, a JSON serializer is used to store data in ZooKeeper. Use this to specify an alternate serializer
-     *
-     * @param serializer serializer to use
-     * @return this (for chaining)
-     */
-    public WorkflowManagerBuilder withSerializer(Serializer serializer)
-    {
-        this.serializer = Preconditions.checkNotNull(serializer, "serializer cannot be null");
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * By default, tasks are run in an internal executor service. Use this to specify a custom executor service
-     * for tasks. This executor does not add any async/concurrency benefit. It's purpose is to allow you to control
-     * which thread executes your tasks.
-     *
-     * @param taskRunnerService custom executor service
-     * @return this (for chaining)
-     */
-    public WorkflowManagerBuilder withTaskRunnerService(Executor taskRunnerService)
-    {
-        this.taskRunnerService = Preconditions.checkNotNull(taskRunnerService, "taskRunnerService cannot be null");
-        return this;
-    }
-
+    
     private WorkflowManagerBuilder()
     {
+        queueFactory = new ZooKeeperSimpleQueueFactory();
         try
         {
             instanceName = InetAddress.getLocalHost().getHostName();
@@ -210,10 +82,5 @@ public class WorkflowManagerBuilder
         {
             instanceName = "unknown";
         }
-    }
-
-    private AutoCleanerHolder newNullHolder()
-    {
-        return new AutoCleanerHolder(null, Duration.ofDays(Integer.MAX_VALUE));
     }
 }

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerKafkaBuilder.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerKafkaBuilder.java
@@ -15,44 +15,24 @@
  */
 package com.nirmata.workflow;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.nirmata.workflow.admin.AutoCleaner;
-import com.nirmata.workflow.details.AutoCleanerHolder;
 import com.nirmata.workflow.details.KafkaHelper;
-import com.nirmata.workflow.details.TaskExecutorSpec;
 import com.nirmata.workflow.details.WorkflowManagerKafkaImpl;
-import com.nirmata.workflow.executor.TaskExecutor;
-import com.nirmata.workflow.models.TaskType;
-import com.nirmata.workflow.queue.QueueFactory;
 import com.nirmata.workflow.queue.kafka.KafkaSimpleQueueFactory;
-import com.nirmata.workflow.serialization.Serializer;
-import com.nirmata.workflow.serialization.StandardSerializer;
 import com.nirmata.workflow.storage.StorageManager;
 import com.nirmata.workflow.storage.StorageManagerMongoImpl;
 import com.nirmata.workflow.storage.StorageManagerNoOpImpl;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.Executor;
 
 /**
  * Builds {@link WorkflowManager} instances
  */
-public class WorkflowManagerKafkaBuilder {
-    private QueueFactory queueFactory = new KafkaSimpleQueueFactory();
-    private String instanceName;
+public class WorkflowManagerKafkaBuilder extends WorkflowManagerBaseBuilder {
     private KafkaHelper kafkaHelper;
     private boolean workflowWorkerEnabled = true;
-    private AutoCleanerHolder autoCleanerHolder = newNullHolder();
-    private Serializer serializer = new StandardSerializer();
-    private Executor taskRunnerService = MoreExecutors.newDirectExecutorService();
     private StorageManager storageManager = new StorageManagerNoOpImpl();
 
-    private final List<TaskExecutorSpec> specs = Lists.newArrayList();
     private String namespace = "";
     private String namespaceVer = "";
 
@@ -143,65 +123,6 @@ public class WorkflowManagerKafkaBuilder {
     }
 
     /**
-     * <p>
-     * Adds a pool of task executors for a given task type to this instance of
-     * the workflow. The specified number of executors are allocated. Call this
-     * method multiple times to allocate executors for the various types of tasks
-     * that will be used in this workflow. You can choose to have all workflow
-     * instances execute all task types or target certain task types to certain
-     * instances.
-     * </p>
-     *
-     * <p>
-     * <code>qty</code> is the maximum concurrency for the given type of task for
-     * this instance.
-     * The logical concurrency for a given task type is the total qty of all
-     * instances in the
-     * workflow. e.g. if there are 3 instances in the workflow and instance A has 2
-     * executors
-     * for task type "a", instance B has 3 executors for task type "a" and instance
-     * C has no
-     * executors for task type "a", the maximum concurrency for task type "a" is 5.
-     * </p>
-     *
-     * <p>
-     * IMPORTANT: every workflow cluster must have at least one instance that has
-     * task executor(s)
-     * for each task type that will be submitted to the workflow. i.e workflows will
-     * stall
-     * if there is no executor for a given task type.
-     * </p>
-     *
-     * @param taskExecutor the executor
-     * @param qty          the number of instances for this pool
-     * @param taskType     task type
-     * @return this (for chaining)
-     */
-    public WorkflowManagerKafkaBuilder addingTaskExecutor(TaskExecutor taskExecutor, int qty, TaskType taskType) {
-        specs.add(new TaskExecutorSpec(taskExecutor, qty, taskType));
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * <p>
-     * Used in reporting. This will be the value recorded as tasks are executed. Via
-     * reporting, you can determine which instance has executed a given task.
-     * </p>
-     *
-     * <p>
-     * Default is: <code>InetAddress.getLocalHost().getHostName()</code>
-     * </p>
-     *
-     * @param instanceName the name of this instance
-     * @return this (for chaining)
-     */
-    public WorkflowManagerKafkaBuilder withInstanceName(String instanceName) {
-        this.instanceName = Preconditions.checkNotNull(instanceName, "instanceName cannot be null");
-        return this;
-    }
-
-    /**
      * Return a new WorkflowManager using the current builder values
      *
      * @return new WorkflowManager
@@ -211,72 +132,13 @@ public class WorkflowManagerKafkaBuilder {
                 instanceName, specs, autoCleanerHolder, serializer, taskRunnerService);
     }
 
-    /**
-     * Currently, only uses Kafka for queuing.
-     * Send side of queue interface not implemented yet, so do not use
-     *
-     * @param queueFactory new queue factory
-     * @return this (for chaining)
-     */
-    public WorkflowManagerKafkaBuilder withQueueFactory(QueueFactory queueFactory) {
-        this.queueFactory = Preconditions.checkNotNull(queueFactory, "queueFactory cannot be null");
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * Sets an auto-cleaner that will run every given period. This is used to clean
-     * old runs.
-     * IMPORTANT: the auto cleaner will only run on the instance that is the current
-     * scheduler.
-     *
-     * @param autoCleaner the auto cleaner to use
-     * @param runPeriod   how often to run
-     * @return this (for chaining)
-     */
-    public WorkflowManagerKafkaBuilder withAutoCleaner(AutoCleaner autoCleaner, Duration runPeriod) {
-        autoCleanerHolder = (autoCleaner == null) ? newNullHolder() : new AutoCleanerHolder(autoCleaner, runPeriod);
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * By default, a JSON serializer is used to store data. Use this to
-     * specify an alternate serializer
-     *
-     * @param serializer serializer to use
-     * @return this (for chaining)
-     */
-    public WorkflowManagerKafkaBuilder withSerializer(Serializer serializer) {
-        this.serializer = Preconditions.checkNotNull(serializer, "serializer cannot be null");
-        return this;
-    }
-
-    /**
-     * <em>optional</em><br>
-     * By default, tasks are run in an internal executor service. Use this to
-     * specify a custom executor service for tasks. This executor does not add any
-     * async/concurrency benefit. It's purpose is to allow you to control which
-     * thread executes your tasks.
-     *
-     * @param taskRunnerService custom executor service
-     * @return this (for chaining)
-     */
-    public WorkflowManagerKafkaBuilder withTaskRunnerService(Executor taskRunnerService) {
-        this.taskRunnerService = Preconditions.checkNotNull(taskRunnerService, "taskRunnerService cannot be null");
-        return this;
-    }
-
     private WorkflowManagerKafkaBuilder() {
+        queueFactory = new KafkaSimpleQueueFactory();
         try {
             instanceName = InetAddress.getLocalHost().getHostName();
         } catch (UnknownHostException e) {
             instanceName = "unknown";
         }
         this.kafkaHelper = new KafkaHelper("localhost:9092", "defaultns", "v1");
-    }
-
-    private AutoCleanerHolder newNullHolder() {
-        return new AutoCleanerHolder(null, Duration.ofDays(Integer.MAX_VALUE));
     }
 }

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerUtil.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerUtil.java
@@ -6,6 +6,22 @@ public class WorkflowManagerUtil {
     private WorkflowManagerUtil() {
     }
 
+    /**
+     * Create and return a Workflow variant based on the type of Workflow used by the client
+     * @see WorkflowManagerKafkaBuilder
+     * @see WorkflowManagerBuilder
+     *
+     * @param curator CuratorFramework
+     * @param kafkaAddress kafka broker address string
+     * @param namespace workflow namespace
+     * @param version workflow version
+     * @param useCuratorForWorkflow whether client uses curator for workflow. This value can be set using an
+     * environment variable which allows easy switching across the workflow types
+     *
+     * @return WorkflowManagerBaseBuilder (for chaining) returns a builder withCurator() if curator is being used
+     * by the client else returns a builder withKafka()
+     */
+
     public static WorkflowManagerBaseBuilder createBuilder(CuratorFramework curator, String kafkaAddress,
             String namespace, String version, boolean useCuratorForWorkflow) {
         if (useCuratorForWorkflow) {

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerUtil.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerUtil.java
@@ -1,0 +1,16 @@
+package com.nirmata.workflow;
+
+import org.apache.curator.framework.CuratorFramework;
+
+public class WorkflowManagerUtil {
+    private WorkflowManagerUtil() {
+    }
+
+    public static WorkflowManagerBaseBuilder createBuilder(CuratorFramework curator, String kafkaAddress,
+            String namespace, String version, boolean useCuratorForWorkflow) {
+        if (useCuratorForWorkflow) {
+            return WorkflowManagerBuilder.builder().withCurator(curator, namespace, version);
+        }
+        return WorkflowManagerKafkaBuilder.builder().withKafka(kafkaAddress, namespace, version);
+    }
+}

--- a/src/main/java/com/nirmata/workflow/WorkflowManagerUtil.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManagerUtil.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2014 Nirmata, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.nirmata.workflow;
 
 import org.apache.curator.framework.CuratorFramework;

--- a/src/test/java/com/nirmata/workflow/TestAdmin.java
+++ b/src/test/java/com/nirmata/workflow/TestAdmin.java
@@ -55,8 +55,8 @@ public class TestAdmin extends BaseForTests
             return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
         };
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, new TaskType("test", "1", true))
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, new TaskType("test", "1", true))
             .build();
         try
         {
@@ -122,8 +122,8 @@ public class TestAdmin extends BaseForTests
             return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "", resultData);
         };
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {
@@ -216,8 +216,8 @@ public class TestAdmin extends BaseForTests
             return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
         };
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {

--- a/src/test/java/com/nirmata/workflow/TestLoadKafka.java
+++ b/src/test/java/com/nirmata/workflow/TestLoadKafka.java
@@ -53,7 +53,6 @@ public class TestLoadKafka extends TestLoadBase {
         cleanDB();
     }
 
-    @Test(enabled = false)
     public void testLoadKafka1() throws Exception {
         TestTaskExecutor taskExecutor = new TestTaskExecutor(getTest1Tasks(), false, getTest1Delay());
         WorkflowManager workflowManager = createWorkflowKafkaBuilder()

--- a/src/test/java/com/nirmata/workflow/TestLoadKafka.java
+++ b/src/test/java/com/nirmata/workflow/TestLoadKafka.java
@@ -30,6 +30,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+@Test(enabled=false)
 public class TestLoadKafka extends TestLoadBase {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private static final String TASKTYPE = "test";

--- a/src/test/java/com/nirmata/workflow/TestLoadZookeeper.java
+++ b/src/test/java/com/nirmata/workflow/TestLoadZookeeper.java
@@ -59,8 +59,8 @@ public class TestLoadZookeeper extends TestLoadBase {
     public void testLoadZkp1() throws Exception {
         TestTaskExecutor taskExecutor = new TestTaskExecutor(getTest1Tasks(), false, getTest1Delay());
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-                .addingTaskExecutor(taskExecutor, 10, new TaskType("test", "1", true))
                 .withCurator(curator, ZKP_NS, ZKP_NS_VER)
+                .addingTaskExecutor(taskExecutor, 10, new TaskType("test", "1", true))
                 .build();
         try {
 

--- a/src/test/java/com/nirmata/workflow/TestNormal.java
+++ b/src/test/java/com/nirmata/workflow/TestNormal.java
@@ -73,8 +73,8 @@ public class TestNormal extends BaseForTests
         };
         TaskType taskType = new TaskType("test", "1", true);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {
@@ -113,8 +113,8 @@ public class TestNormal extends BaseForTests
         TaskExecutor taskExecutor = (w, t) -> () -> new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
         TaskType taskType = new TaskType("test", "1", true);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withAutoCleaner(new StandardAutoCleaner(Duration.ofMillis(1)), Duration.ofMillis(1))
             .build();
         try
@@ -155,8 +155,8 @@ public class TestNormal extends BaseForTests
         };
         TaskType taskType = new TaskType("test", "1", true);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {
@@ -184,8 +184,8 @@ public class TestNormal extends BaseForTests
     {
         TestTaskExecutor taskExecutor = new TestTaskExecutor(6);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, new TaskType("test", "1", true))
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, new TaskType("test", "1", true))
             .build();
         try
         {
@@ -232,8 +232,8 @@ public class TestNormal extends BaseForTests
         for ( int i = 0; i < QTY; ++i )
         {
             WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-                .addingTaskExecutor(taskExecutor, 10, taskType)
                 .withCurator(curator, "test", "1")
+                .addingTaskExecutor(taskExecutor, 10, taskType)
                 .build();
             workflowManagers.add(workflowManager);
         }
@@ -269,8 +269,8 @@ public class TestNormal extends BaseForTests
     public void testNoData() throws Exception
     {
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(new TestTaskExecutor(1), 10, new TaskType("test", "1", true))
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(new TestTaskExecutor(1), 10, new TaskType("test", "1", true))
             .build();
 
         Optional<TaskExecutionResult> taskData = workflowManager.getTaskExecutionResult(new RunId(), new TaskId());
@@ -290,8 +290,8 @@ public class TestNormal extends BaseForTests
         };
         TaskType taskType = new TaskType("test", "1", true);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {
@@ -335,8 +335,8 @@ public class TestNormal extends BaseForTests
         };
         TaskType taskType = new TaskType("test", "1", true);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {
@@ -388,8 +388,8 @@ public class TestNormal extends BaseForTests
             return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "test", Maps.newHashMap(), subTaskRunId);
         };
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {
@@ -422,10 +422,10 @@ public class TestNormal extends BaseForTests
 
         TestTaskExecutor taskExecutor = new TestTaskExecutor(6);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
+            .withCurator(curator, "test", "1")
             .addingTaskExecutor(taskExecutor, 10, taskType1)
             .addingTaskExecutor(taskExecutor, 10, taskType2)
             .addingTaskExecutor(taskExecutor, 10, taskType3)
-            .withCurator(curator, "test", "1")
             .build();
         try
         {
@@ -481,10 +481,10 @@ public class TestNormal extends BaseForTests
         };
 
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
+            .withCurator(curator, "test", "1")
             .addingTaskExecutor(taskExecutor1, 10, taskType1)
             .addingTaskExecutor(taskExecutor2, 10, taskType2)
             .addingTaskExecutor(taskExecutor3, 10, taskType3)
-            .withCurator(curator, "test", "1")
             .build();
         try
         {

--- a/src/test/java/com/nirmata/workflow/TestNormalKafka.java
+++ b/src/test/java/com/nirmata/workflow/TestNormalKafka.java
@@ -87,7 +87,6 @@ public class TestNormalKafka extends BaseForTests {
         log.info("====Done test {}====", method.getName());
     }
 
-    @Test(enabled = true)
     public void testFailedStop() throws Exception {
         TestTaskExecutor taskExecutor = new TestTaskExecutor(2) {
             @Override
@@ -131,7 +130,6 @@ public class TestNormalKafka extends BaseForTests {
     // Running this test last, because, autocleaner
     // might clear runs unexpectedly especially if tests
     // are run in parallel
-    @Test(enabled = true)
     public void zzTestAutoCleanRun() throws Exception {
 
         TaskExecutor taskExecutor = (w, t) -> () -> new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
@@ -155,7 +153,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testCanceling() throws Exception {
         Semaphore executionLatch = new Semaphore(0);
         CountDownLatch continueLatch = new CountDownLatch(1);
@@ -191,7 +188,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testSingleClientSimple() throws Exception {
         TestTaskExecutor taskExecutor = new TestTaskExecutor(6);
         WorkflowManager workflowManager = createWorkflowKafkaBuilder()
@@ -249,7 +245,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testMultiClientSimple() throws Exception {
         final int QTY = 4;
 
@@ -290,7 +285,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testDuplicateSubmit() throws Exception {
         // One more than 6 tasks in the DAG
         TestTaskExecutor taskExecutor = new TestTaskExecutor(7);
@@ -314,7 +308,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = false)
     public void testExpiry() throws Exception {
         // To enable this test, match the value of the equivalent constant in
         // SchedulerKafka class with value below
@@ -348,7 +341,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testNoData() throws Exception {
         WorkflowManager workflowManager = createWorkflowKafkaBuilder()
                 .addingTaskExecutor(new TestTaskExecutor(1), 10, new TaskType("test", "1", true))
@@ -358,7 +350,6 @@ public class TestNormalKafka extends BaseForTests {
         Assert.assertFalse(taskData.isPresent());
     }
 
-    @Test(enabled = true)
     public void testTaskData() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         TaskExecutor taskExecutor = (w, t) -> () -> {
@@ -394,7 +385,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testTaskProgress() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         TaskExecutor taskExecutor = (w, t) -> () -> {
@@ -430,7 +420,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testSubTask() throws Exception {
         TaskType taskType = new TaskType("test", "1", true);
         Task groupAChild = new Task(new TaskId(), taskType);
@@ -481,7 +470,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testMultiTypesExecution() throws Exception {
         TaskType taskType1 = new TaskType("type1", "1", true);
         TaskType taskType2 = new TaskType("type2", "1", true);
@@ -520,7 +508,6 @@ public class TestNormalKafka extends BaseForTests {
         }
     }
 
-    @Test(enabled = true)
     public void testMultiTypes() throws Exception {
         TaskType taskType1 = new TaskType("type1", "1", true);
         TaskType taskType2 = new TaskType("type2", "1", true);

--- a/src/test/java/com/nirmata/workflow/TestNormalKafka.java
+++ b/src/test/java/com/nirmata/workflow/TestNormalKafka.java
@@ -64,6 +64,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+@Test(enabled=false)
 public class TestNormalKafka extends BaseForTests {
     protected Properties kafkaProps = new Properties();
     protected final Timing timing = new Timing();

--- a/src/test/java/com/nirmata/workflow/TestParentNodeDeletion.java
+++ b/src/test/java/com/nirmata/workflow/TestParentNodeDeletion.java
@@ -118,7 +118,6 @@ public class TestParentNodeDeletion extends BaseForTests
         Duration runPeriod = Duration.ofSeconds(5);
         AutoCleaner cleaner = new StandardAutoCleaner(Duration.ofSeconds(5));
 
-        final WorkflowManagerBuilder workflowManagerBuilder = WorkflowManagerBuilder.builder().withCurator(curator, namespace, VERSION).withAutoCleaner(cleaner, runPeriod);
 
         final TaskExecutor taskExecutor = (workflowManager, executableTask) -> () -> {
             final String runId = executableTask.getRunId().getId();
@@ -128,9 +127,11 @@ public class TestParentNodeDeletion extends BaseForTests
             return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
         };
 
-        workflowManagerBuilder.addingTaskExecutor(taskExecutor, CONCURRENT_TASKS, TASK_TYPE);
-
-        final WorkflowManager workflowManager = workflowManagerBuilder.build();
+        final WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
+                .withCurator(curator, namespace, VERSION)
+                .withAutoCleaner(cleaner, runPeriod)
+                .addingTaskExecutor(taskExecutor, CONCURRENT_TASKS, TASK_TYPE)
+                .build();
         workflowManager.start();
 
         return workflowManager;

--- a/src/test/java/com/nirmata/workflow/TestWorkflowListenerManager.java
+++ b/src/test/java/com/nirmata/workflow/TestWorkflowListenerManager.java
@@ -38,8 +38,8 @@ public class TestWorkflowListenerManager extends BaseForTests
         TestTaskExecutor taskExecutor = new TestTaskExecutor(6);
         TaskType taskType = new TaskType("test", "1", true);
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build();
         try
         {

--- a/src/test/java/com/nirmata/workflow/details/TestDelayPriorityTasks.java
+++ b/src/test/java/com/nirmata/workflow/details/TestDelayPriorityTasks.java
@@ -49,8 +49,8 @@ public class TestDelayPriorityTasks extends BaseForTests
         };
         TaskType taskType = new TaskType("test", "1", true, TaskMode.DELAY);
         try ( WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 10, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 10, taskType)
             .build() )
         {
             workflowManager.start();
@@ -91,8 +91,8 @@ public class TestDelayPriorityTasks extends BaseForTests
         };
         TaskType taskType = new TaskType("test", "1", true, TaskMode.PRIORITY);
         try ( WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
-            .addingTaskExecutor(taskExecutor, 1, taskType)
             .withCurator(curator, "test", "1")
+            .addingTaskExecutor(taskExecutor, 1, taskType)
             .build() )
         {
             SimpleQueue.debugQueuedTasks = new Semaphore(0);

--- a/src/test/java/com/nirmata/workflow/details/TestDisruptedScheduler.java
+++ b/src/test/java/com/nirmata/workflow/details/TestDisruptedScheduler.java
@@ -95,8 +95,8 @@ public class TestDisruptedScheduler
             };
 
             workflowManager = WorkflowManagerBuilder.builder()
-                .addingTaskExecutor(taskExecutor, 10, taskType)
                 .withCurator(curator, "test", "1")
+                .addingTaskExecutor(taskExecutor, 10, taskType)
                 .withInstanceName("i-" + id)
                 .build();
             workflowManager.start();

--- a/src/test/java/com/nirmata/workflow/details/TestEdges.java
+++ b/src/test/java/com/nirmata/workflow/details/TestEdges.java
@@ -86,8 +86,8 @@ public class TestEdges extends BaseForTests
         List<WorkflowManager> workflowManagers = IntStream.range(0, WORKFLOW_QTY).mapToObj(i -> {
             TaskType type = ((i & 1) != 0) ? type1 : type2;
             return WorkflowManagerBuilder.builder()
-                .addingTaskExecutor(taskExecutor, 10, type)
                 .withCurator(curator, "test-" + i, "1")
+                .addingTaskExecutor(taskExecutor, 10, type)
                 .build();
         }).collect(Collectors.toList());
         try
@@ -133,9 +133,9 @@ public class TestEdges extends BaseForTests
             return new TaskExecutionResult(TaskExecutionStatus.SUCCESS, "");
         };
         WorkflowManager workflowManager = WorkflowManagerBuilder.builder()
+            .withCurator(curator, "test", "1")
             .addingTaskExecutor(taskExecutor, 10, idempotentType)
             .addingTaskExecutor(taskExecutor, 10, nonIdempotentType)
-            .withCurator(curator, "test", "1")
             .build();
         try
         {


### PR DESCRIPTION
This PR makes WorkflowManagerBaseBuilder a parent class for WorkflowManagerKafkaBuilder and WorkflowManagerBuilder. While this implementation reduces boilerplate, it also opens up prospects for easy switching of workflow type (from Kafka based to Curator based and vice-versa) as both the variants of the builders inherit from a base class which opens up prospects for chaining the withCurator or withKafka methods, while building the Manager depending upon the type of workflow being used.