### PR TITLE
implement direct submission of tasks

### DIFF
--- a/src/main/java/com/nirmata/workflow/WorkflowManager.java
+++ b/src/main/java/com/nirmata/workflow/WorkflowManager.java
@@ -99,6 +99,14 @@ public interface WorkflowManager extends Closeable
     RunId submitSubTask(RunId runId, RunId parentRunId, Task task);
 
     /**
+     * Submit a task directly to executor. Only the top parent is executed, not children.
+     * The executor in turn, will not attempt to send task results to the scheduler.
+     *
+     * @param task task to execute
+     */
+    void submitSimpleTaskDirect(Task task);
+
+    /**
      * Update task progress info. This method is meant to be used inside of {@link TaskExecutor}
      * for a running task to update its execution progress(0-100).
      *

--- a/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
+++ b/src/main/java/com/nirmata/workflow/details/WorkflowManagerImpl.java
@@ -601,4 +601,10 @@ public class WorkflowManagerImpl implements WorkflowManager, WorkflowAdmin
 
         return builder.build();
     }
+    
+    @Override
+    public void submitSimpleTaskDirect(Task task)
+    {
+        throw(new UnsupportedOperationException("Direct submission is unsupported in Zookeeper based workflow"));
+    }
 }


### PR DESCRIPTION
Submit simple tasks directly to the Kafka queue. Similar to what `queueTask(...)` does in `SchedulerKafka.java`